### PR TITLE
Added status/2 and full_status/2 to pass timeout value

### DIFF
--- a/src/poolboy.erl
+++ b/src/poolboy.erl
@@ -4,7 +4,8 @@
 
 -export([checkout/1, checkout/2, checkout/3, checkin/2, transaction/2,
          transaction/3, child_spec/2, child_spec/3, start/1, start/2,
-         start_link/1, start_link/2, stop/1, status/1, full_status/1]).
+         start_link/1, start_link/2, stop/1, status/1, status/2,
+         full_status/1, full_status/2]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2,
          code_change/3]).
 -export_type([pool/0]).
@@ -123,9 +124,17 @@ stop(Pool) ->
 status(Pool) ->
     gen_server:call(Pool, status).
 
+-spec status(Pool :: pool(), Timeout :: pos_integer()) -> {atom(), integer(), integer(), integer()}.
+status(Pool) ->
+    gen_server:call(Pool, status, Timeout).
+
 -spec full_status(Pool :: pool()) -> proplists:proplist().
 full_status(Pool) ->
     gen_server:call(Pool, full_status).
+
+-spec full_status(Pool :: pool(), Timeout :: pos_integer()) -> proplists:proplist().
+full_status(Pool, Timeout) ->
+    gen_server:call(Pool, full_status, Timeout).
 
 init({PoolArgs, WorkerArgs}) ->
     process_flag(trap_exit, true),


### PR DESCRIPTION
When pulling the status for monitoring we want to be able configure a timeout shorter than the default gen_server timeout. This exposes `status/2` and `full_status/2` in which a timeout value can be passed through. `status/1` and `full_status/1` retain the default timeout behaviour.